### PR TITLE
Keyword group 패딩추가, 초기페이지 반응형 깨짐 수정

### DIFF
--- a/src/components/Keyword/KeywordGroup.jsx
+++ b/src/components/Keyword/KeywordGroup.jsx
@@ -4,7 +4,7 @@ import Keyword from './Keyword';
 
 const KeywordGroup = ({ keywords, selectedKeywords, onSelectKeyword }) => (
   <div className="w-full flex justify-center mt-5">
-    <div className="flex flex-col items-center w-[80%] gap-[17px] px-0 py-[13px] bg-system-colors-overlays-default rounded-[10px]">
+    <div className="flex flex-col items-center w-[80%] gap-[17px] px-4 py-4 bg-system-colors-overlays-default rounded-[10px]">
       <div className="relative self-stretch mt-[-1.00px] font-bold text-black text-lg text-center">
         만남을 나타내는 키워드를 선택하세요!
       </div>

--- a/src/routes/MainPage.jsx
+++ b/src/routes/MainPage.jsx
@@ -103,7 +103,7 @@ const MainPage = ({ setResults }) => {
           <Search onNormalMode={handleNormalMode} />
         </div>
       ) : (
-        <div className="bg-white w-full md:min-w-[min(600px,30%)] md:w-80 h-full relative">
+        <div className="bg-white w-full md:min-w-[min(600px,30%)] md:w-[353px] h-full relative">
           <div className="absolute w-full h-full top-0 left-0 rounded-md shadow-[0px_4px_4px_#00000040] [background:linear-gradient(180deg,rgb(193,219,229)_0%,rgb(197,210,229)_100%)] flex flex-col gap-4 p-8">
             <StartPointGroup points={startPoints} onAddPoint={handleAddStartPoint} onDeletePoint={handleDeleteStartPoint} onSearchMode={handleSearchMode} />
             <KeywordGroup keywords={keywords} selectedKeywords={selectedKeywords} onSelectKeyword={handleSelectKeyword} />

--- a/src/routes/ResultPage.jsx
+++ b/src/routes/ResultPage.jsx
@@ -47,6 +47,7 @@ const ResultPage = ({ results, setResults }) => {
   const handleBackToMain = () => {
     navigate('/'); // Navigate to the main page route ('/')
   };
+  
   return (
     <div className="relative w-full h-screen">
       <div id="map" className="absolute inset-0 w-full h-full z-0"></div>


### PR DESCRIPTION
Keyword group에서 패딩 없어서 딱 붙어있었던 점 수정

메인페이지에서 md: 조건 중 일부 (768px ~ 1175px 너비) 에서, 경로 3개 이상 추가했을 때 화면 넘어감을 확인
=> md:w-80 은 20rem (320px) 인데, 최소 352.8px 은 되어야 안깨지더라고요
그래서 그냥 하드코딩했음! 너비 어떻게 바뀌어도 이쁘게 잘 나옵니다 이제

![image](https://github.com/user-attachments/assets/55d6d471-4a52-43ed-a1eb-4bda2876758e)
